### PR TITLE
Add isDependent to DRY up similar code

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -606,15 +606,39 @@ abstract class Association
     }
 
     /**
-     * Sets whether the records on the target table are dependent on the source table.
+     * Whether the association record is dependent on the owning record.
      *
      * This is primarily used to indicate that records should be removed if the owning record in
      * the source table is deleted.
      *
+     * @param \Cake\Datasource\EntityInterface $entity The entity that might be deletable because it's dependent on it's source.
      * @return bool
+     */
+    public function isDependent(EntityInterface $entity)
+    {
+        $dependent = $this->getDependent();
+
+        if (is_callable($dependent)) {
+            $dependent = (bool)$dependent($entity);
+        }
+
+        return $dependent;
+    }
+
+    /**
+     * Gets the _dependent property on the source table.
+     *
+     * This is primarily used to indicate that records should be removed if the owning record in
+     * the source table is deleted.
+     *
+     * This is usually a boolean but it can also be a callable that acts on the associated entity.
+     *
+     * @return bool|callable
      */
     public function getDependent()
     {
+        $dependent = $this->_dependent;
+
         return $this->_dependent;
     }
 

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -586,13 +586,7 @@ class BelongsToMany extends Association
      */
     public function cascadeDelete(EntityInterface $entity, array $options = [])
     {
-        $dependent = $this->getDependent();
-
-        if (is_callable($dependent)) {
-            $dependent = (bool)$dependent($entity);
-        }
-
-        if ($dependent === false) {
+        if ($this->isDependent($entity) === false) {
             return true;
         }
 

--- a/src/ORM/Association/DependentDeleteHelper.php
+++ b/src/ORM/Association/DependentDeleteHelper.php
@@ -37,13 +37,7 @@ class DependentDeleteHelper
      */
     public function cascadeDelete(Association $association, EntityInterface $entity, array $options = [])
     {
-        $dependent = $association->getDependent();
-
-        if (is_callable($dependent)) {
-            $dependent = (bool)$dependent($entity);
-        }
-
-        if ($dependent === false) {
+        if ($association->isDependent($entity) === false) {
             return true;
         }
 


### PR DESCRIPTION
- Since $_dependent can now also be a callable that returns bool, I think it makes sense to have a separate public method that actually tells you if an entity is deletable if it's source is.
- I didn't want to make getDependent() do anything outside of getting a property, which previously was just a boolean.
- The new method will tell you if this specific entity is subject to being deleted if it's source is.